### PR TITLE
Add PyPI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Rank-biased Overlap (RBO)
 [![CircleCI](https://circleci.com/gh/changyaochen/rbo/tree/master.svg?style=svg)](https://circleci.com/gh/changyaochen/rbo/tree/master)
+[![PyPI version](https://badge.fury.io/py/rbo.svg)](https://badge.fury.io/py/rbo)
 
 This project contains a Python implementation of Rank-Biased Overlap (RBO) from: Webber, William, Alistair Moffat, and Justin Zobel. "A similarity measure for indefinite rankings." ACM Transactions on Information Systems (TOIS) 28.4 (2010): 20." ([Download][paper]).
 


### PR DESCRIPTION
As promised, this will add a small badge to the top of the README showing the availability on PyPI including its current version number:

![image](https://user-images.githubusercontent.com/29141485/108686353-93c67b00-74f5-11eb-86fb-d47c5b4b1423.png)
